### PR TITLE
Fix carousel image centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,20 +56,30 @@
               <li data-target="#carouselExampleIndicators" data-slide-to="4"></li>
             </ol>
             <div class="carousel-inner">
-              <div class="carousel-item active car-fix">
-                <img src="images_videos/edited10_58.jpg" alt="...">
+              <div class="carousel-item active">
+                <div class="carousel-image-wrapper">
+                    <img src="images_videos/edited10_58.jpg" alt="...">
+                </div>
               </div>
-              <div class="carousel-item fix-wd">
-                <img src="images_videos/main_img.jpg" alt="...">
+              <div class="carousel-item">
+                <div class="carousel-image-wrapper">
+                    <img src="images_videos/main_img.jpg" alt="...">
+                </div>
               </div>
-              <div class="carousel-item car-fix">
-                <img src= "images_videos/9_39.png" alt="...">
+              <div class="carousel-item">
+                <div class="carousel-image-wrapper">
+                    <img src= "images_videos/9_39.png" alt="...">
+                </div>
               </div>
-              <div class="carousel-item fix-wd">
-                <img src= "images_videos/11_02.jpg" alt="...">
+              <div class="carousel-item">
+                <div class="carousel-image-wrapper">
+                    <img src= "images_videos/11_02.jpg" alt="...">
+                </div>
               </div>
-              <div class="carousel-item car-fix">
-                <img src= "images_videos/12_04.png" alt="...">
+              <div class="carousel-item">
+                <div class="carousel-image-wrapper">
+                    <img src= "images_videos/12_04.png" alt="...">
+                </div>
               </div>
 
             </div>

--- a/styles.css
+++ b/styles.css
@@ -102,11 +102,18 @@ video {
     position: relative; /* Set position for absolute positioning of images */
 }
 
-.carousel img {
-    width: auto; /* Set auto width for images */
-    height: 100%; /* Set 100% height to fill the carousel container */
-    display: block; /* Remove any default inline spacing */
-    margin: 0 auto; /* Center images horizontally */
+.carousel-inner,
+.carousel-item {
+    width: 100%;
+    height: 100%;
+}
+
+.carousel-image-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
 }
 
 
@@ -176,32 +183,10 @@ hr {
         max-width: 450px;
     }
 
-    /* .carousel-item {
-        height: 300px;
-        overflow: hidden;
-        width: 100%;
-
-    } */
-
     #carouselExampleIndicators {
         height: 400px;
         width: auto;
     }
-
-    .fix-wd {
-        width: 450px !important;
-        margin-left: auto;
-        margin-right: auto;
-    }
-    .car-fix {
-        padding-bottom: 45% !important;
-        height: auto;
-        width: 450x;
-    }
-
-     .carousel-item img {
-        width: 100%;
-        }
 
     br.laptop-view {
         display: none;


### PR DESCRIPTION
I added a wrapper div around the images that expands to the full width and height of the carousel, and then centers its children using [flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container).